### PR TITLE
Fix inconsistency of buttons and fix toolbar appearance

### DIFF
--- a/src/gtk-3.0/gtk-widgets.css
+++ b/src/gtk-3.0/gtk-widgets.css
@@ -65,12 +65,16 @@ button.flat {
 	background-color: transparent;
 	border: 1px solid transparent;
 }
-button:not(.flat) , 
+button:not(.flat),
 .button {
-	background-color: @theme_selected_bg_color;
-	border: 1px solid black;
+	background-color: #D2D4D2;
+	border: 1px solid #989B98;
 	border-radius: 3px;
 	padding: .35em;
+}
+button:not(.flat):hover, .button:not(.flat):hover {
+	background-color: @theme_selected_bg_color;
+	border: 1px solid black;
 }
 button:active, .button:active,
 button:active:hover, .button:active:hover,
@@ -136,19 +140,19 @@ scrollbar.horizontal slider {
 	min-width: .5rem;
 }
 scrollbar.vertical button.up {
-	min-height: 0.5rem;
+	min-height: 0.25rem;
 	-gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
 }
 scrollbar.vertical button.down {
-	min-height: 0.5rem;
+	min-height: 0.25rem;
 	-gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
 }
 scrollbar.horizontal button.up {
-	min-width: 0.5rem;
+	min-width: 0.25rem;
 	-gtk-icon-source: -gtk-icontheme("pan-start-symbolic");
 }
 scrollbar.horizontal button.down {
-	min-width: 0.5rem;
+	min-width: 0.25rem;
 	-gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
 }
 
@@ -467,7 +471,12 @@ toolbar separator {
 toolbar button {
 	background: none;
 	border: 1px solid transparent;
+	border-radius: 3px;
 	padding: .35em;
+}
+toolbar button:hover {
+	background-color: @theme_selected_bg_color;
+	border: 1px solid black;
 }
 toolbar button:disabled {
 	background: none;


### PR DESCRIPTION
GTK+ 2 vs. 3 (or the other way around, I'm confused):

![2vs3](https://user-images.githubusercontent.com/1471149/118443262-5b010100-b6f4-11eb-8c62-bc4806bdabad.png)

Previously, toolbar buttons had square borders when clicked, and no border on mouseover. The color of regular buttons didn't change on mouseover (a regression) and now it does. Also, the size of scrollbar buttons was inconsistent between GTK+ 2 and 3.