### PR TITLE
Fix small size of gpicview toolbar buttons

### DIFF
--- a/src/gtk-3.0/gtk-widgets.css
+++ b/src/gtk-3.0/gtk-widgets.css
@@ -64,6 +64,7 @@ rubberband {
 button.flat {
 	background-color: transparent;
 	border: 1px solid transparent;
+	padding: .35em;
 }
 button:not(.flat),
 .button {


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/1471149/119610905-a1e0ac00-be02-11eb-9455-517303dc22aa.png)

After:
![after](https://user-images.githubusercontent.com/1471149/119610903-a1481580-be02-11eb-9344-9291105b9aa1.png)
