### PR TITLE
Restrict scrolledwindow frame border to sidebar

### DIFF
--- a/src/gtk-3.0/gtk-widgets.css
+++ b/src/gtk-3.0/gtk-widgets.css
@@ -743,8 +743,8 @@ switch:checked slider {
 	background: @theme_base_color;
 }
 .sidebar,
-scrolledwindow,
-scrolledwindow.frame {
+.sidebar scrolledwindow,
+.sidebar scrolledwindow.frame {
 	border-image: url("assets/frame-etched-out.png") 3 / 3px stretch;
 	padding: 2px;
 }


### PR DESCRIPTION
The original declaration is likely an oversight, which leads to
unnecessary - often ugly looking - framed-in-the-frame boxes.